### PR TITLE
添加队列处理的相关事件

### DIFF
--- a/src/queue/Worker.php
+++ b/src/queue/Worker.php
@@ -32,11 +32,11 @@ class Worker
         $job = $this->getNextJob($queue);
 
         if (!is_null($job)) {
-            Hook::listen('worker_before_process',$queue);
+            Hook::listen('worker_before_process', $queue);
             return $this->process($job, $maxTries, $delay);
         }
 
-        Hook::listen('worker_before_sleep',$queue);
+        Hook::listen('worker_before_sleep', $queue);
         $this->sleep($sleep);
 
         return ['job' => null, 'failed' => false];

--- a/src/queue/Worker.php
+++ b/src/queue/Worker.php
@@ -32,9 +32,11 @@ class Worker
         $job = $this->getNextJob($queue);
 
         if (!is_null($job)) {
+            Hook::listen('worker_before_process',$queue);
             return $this->process($job, $maxTries, $delay);
         }
 
+        Hook::listen('worker_before_sleep',$queue);
         $this->sleep($sleep);
 
         return ['job' => null, 'failed' => false];
@@ -97,7 +99,7 @@ class Worker
                 $job->delete();
                 $job->failed();
             } finally {
-                Hook::listen('queue.failed', $job);
+                Hook::listen('queue_failed', $job);
             }
         }
 

--- a/src/queue/command/Work.php
+++ b/src/queue/command/Work.php
@@ -65,7 +65,7 @@ class Work extends Command
         $memory = $input->getOption('memory');
 
         if ($input->getOption('daemon')) {
-            Hook::listen('worker_daemon_start',$queue);
+            Hook::listen('worker_daemon_start', $queue);
             $this->daemon(
                 $queue, $delay, $memory,
                 $input->getOption('sleep'), $input->getOption('tries')
@@ -109,12 +109,12 @@ class Work extends Command
             );
 
             if ( $this->memoryExceeded($memory) ) {
-                Hook::listen('worker_memory_exceeded',$queue);
+                Hook::listen('worker_memory_exceeded', $queue);
                 $this->stop();
             }
             
             if ( $this->queueShouldRestart($lastRestart) ) {
-                Hook::listen('worker_queue_restart',$queue);
+                Hook::listen('worker_queue_restart', $queue);
                 $this->stop();
             }
         }

--- a/src/queue/command/Work.php
+++ b/src/queue/command/Work.php
@@ -65,6 +65,7 @@ class Work extends Command
         $memory = $input->getOption('memory');
 
         if ($input->getOption('daemon')) {
+            Hook::listen('worker_daemon_start',$queue);
             $this->daemon(
                 $queue, $delay, $memory,
                 $input->getOption('sleep'), $input->getOption('tries')
@@ -107,7 +108,13 @@ class Work extends Command
                 $queue, $delay, $sleep, $maxTries
             );
 
-            if ($this->memoryExceeded($memory) || $this->queueShouldRestart($lastRestart)) {
+            if ( $this->memoryExceeded($memory) ) {
+                Hook::listen('worker_memory_exceeded',$queue);
+                $this->stop();
+            }
+            
+            if ( $this->queueShouldRestart($lastRestart) ) {
+                Hook::listen('worker_queue_restart',$queue);
                 $this->stop();
             }
         }


### PR DESCRIPTION
1. 失败事件由 queue.failed 修改为 queue_failed ,以符合最新的官方行为命名规范
2. worker 类中添加若干钩子，包括：
- worker_daemon_start ,         在 worker 进程以 daemon  方式启动前触发
- worker_before_process,        在 worker 进程的循环过程中获取到任务之后开始处理该任务之前触发
- worker_before_sleep,            在 worker 进程的循环过程中因没有获取到任务而准备sleep之前触发
- worker_memory_exceeded , 在 worker 进程因内存超限而自动退出前触发
- worker_queue_restart ,         在 worker 进程收到 queue:restart 命令而自动退出前触发
3. 增加上述事件的作用是方便第三方开发者进行监控或记录。