### PR TITLE
fixes #33 queue:listen 模式下,worker 子进程的 cwd 异常的bug

### DIFF
--- a/src/queue/command/Listen.php
+++ b/src/queue/command/Listen.php
@@ -36,7 +36,7 @@ class Listen extends Command
 
     public function initialize(Input $input, Output $output)
     {
-        $this->listener = new Listener(getcwd());
+        $this->listener = new Listener($this->findCommandPath());
         $this->listener->setSleep($input->getOption('sleep'));
         $this->listener->setMaxTries($input->getOption('tries'));
 
@@ -56,5 +56,10 @@ class Listen extends Command
         $queue = $input->getOption('queue') ?: 'default';
 
         $this->listener->listen($queue, $delay, $memory, $timeout);
+    }
+    
+    protected function findCommandPath()
+    {
+        return defined('ROOT_PATH') ? ROOT_PATH : dirname($_SERVER['argv'][0]);
     }
 }


### PR DESCRIPTION
worker 进程是由 `think-queue/src/queue/Listener.php`  类通过 `makeProcess() `方法创建的.  
在 `makeProcess()` 方法中, worker 进程的 cwd 被设置为 Listener 对象的 `$commandPath` 属性的值.  
而 Listener 对象是由 `think-queue/src/queue/command/Listen.php` 创建的,且 Listener 对象的 `commandPath ` 属性被设置为脚本执行时的 cwd .  
因此导致 bug https://github.com/top-think/think-queue/issues/33 中的问题.  

本PR中,创建 Listener 对象时,其`commandPath`属性被设置为项目根目录,而不是脚本运行时的cwd.