### PR TITLE
解决了在listen模式下CPU占用率高的问题

### DIFF
--- a/src/queue/Listener.php
+++ b/src/queue/Listener.php
@@ -65,6 +65,7 @@ class Listener
 
         while (true) {
             $this->runProcess($process, $memory);
+            sleep($this->sleep);
         }
     }
 
@@ -93,7 +94,7 @@ class Listener
     public function makeProcess($queue, $delay, $memory, $timeout)
     {
         $string  = $this->workerCommand;
-        $command = sprintf($string, $queue, $delay, $memory, $this->sleep, $this->maxTries);
+        $command = sprintf($string, $queue, $delay, $memory, 0, $this->maxTries);
 
         return new Process($command, $this->commandPath, null, null, $timeout);
     }


### PR DESCRIPTION
修改了listener负责创建进程的循环.
现在当上一个进程退出时, listener会等待sleep参数指定的时间之后再创建新的子进程, worker进程的等待时间提前到listener中, 防止在队列为空的情况下长时间占用CPU资源.
遗留问题: 当队列不为空时在两次执行之间就会有额外的等待时间