### PR TITLE
Update Database.php

### DIFF
--- a/src/queue/connector/Database.php
+++ b/src/queue/connector/Database.php
@@ -147,7 +147,7 @@ class Database extends Connector
             ->where('queue', $this->getQueue($queue))
             ->where('reserved', 1)
             ->where('reserved_at', '<=', $expired)
-            ->exp('attempts'    , 'attempts + 1')
+            ->exp('attempts', 'attempts + 1')
             ->update([
                 'reserved'    => 0,
                 'reserved_at' => null

--- a/src/queue/connector/Database.php
+++ b/src/queue/connector/Database.php
@@ -147,10 +147,10 @@ class Database extends Connector
             ->where('queue', $this->getQueue($queue))
             ->where('reserved', 1)
             ->where('reserved_at', '<=', $expired)
+            ->exp('attempts'    , 'attempts + 1')
             ->update([
                 'reserved'    => 0,
-                'reserved_at' => null,
-                'attempts'    => ['exp', 'attempts + 1']
+                'reserved_at' => null
             ]);
     }
 


### PR DESCRIPTION
thinkphp V5.0.18以后 exp 表达式被丢弃，采用了 exp ()方法 
手册参见 [查询语法](https://www.kancloud.cn/manual/thinkphp5/135182)