### PR TITLE
Fixed a problem...click me read detail.

### DIFF
--- a/src/queue/Job.php
+++ b/src/queue/Job.php
@@ -147,7 +147,7 @@ abstract class Job
                 list($module, $name) = explode('/', $name, 2);
             }
 
-            $name = Config::get('app_namespace') . ($module ? '\\' . strtolower($module) : '') . '\\job\\' . $name;
+            $name = Config::has('app_namespace') ? Config::get('app_namespace') : 'app' . ($module ? '\\' . strtolower($module) : '') . '\\job\\' . $name;
         }
         if (class_exists($name)) {
             return new $name();


### PR DESCRIPTION
Fixed a problem with job class in app\job but use class name only can not found class. This problem by reason of not set app_namespace in Config.php.

我特么为什么要用英文！

---

因为 Config.php 未设置 `app_namespace` 导致创建 `Job` 只传入类名时无法执行任务而必须传入完整的路径如 `app\job\Test@fire`，判断 `app_namespace` 不存在给个默认的 `app` 就好了