### PR TITLE
修复关闭超时任务重试功能

### DIFF
--- a/src/queue/connector/Redis.php
+++ b/src/queue/connector/Redis.php
@@ -103,7 +103,7 @@ class Redis extends Connector
             }
         };
 
-        return new self($redis, $config['queue'], $config['retry_after'] ?? 60, $config['block_for'] ?? null);
+        return new self($redis, $config['queue'], is_null($config['retry_after']) ? $config['retry_after'] : ($config['retry_after'] ?? 60), $config['block_for'] ?? null);
     }
 
     public function size($queue = null)


### PR DESCRIPTION
无法将retry_after设置为null，导致无法关闭超时任务重试功能，