### PR TITLE
修正Sync驱动，实例化Job事件时，参数类型错误

### DIFF
--- a/src/queue/connector/Sync.php
+++ b/src/queue/connector/Sync.php
@@ -32,14 +32,14 @@ class Sync extends Connector
         $queueJob = $this->resolveJob($this->createPayload($job, $data), $queue);
 
         try {
-            $this->triggerEvent(new JobProcessing($this->connection, $job));
+            $this->triggerEvent(new JobProcessing($this->connection, $queueJob));
 
             $queueJob->fire();
 
-            $this->triggerEvent(new JobProcessed($this->connection, $job));
+            $this->triggerEvent(new JobProcessed($this->connection, $queueJob));
         } catch (Exception | Throwable $e) {
 
-            $this->triggerEvent(new JobFailed($this->connection, $job, $e));
+            $this->triggerEvent(new JobFailed($this->connection, $queueJob, $e));
 
             throw $e;
         }


### PR DESCRIPTION
JobProcessing、JobProcessed、JobFailed 实例化时参数`$job`需要类型`think\queue\Job`,而目前类型是任务类的本身